### PR TITLE
Force rings to have seperate prop ids

### DIFF
--- a/Chroma/Colorizer/LightColorizer.cs
+++ b/Chroma/Colorizer/LightColorizer.cs
@@ -136,11 +136,23 @@
 
                     Lights = lse.GetField<LightWithIdManager, LightSwitchEventEffect>("_lightManager").GetField<List<ILightWithId>[], LightWithIdManager>("_lights")[lse.lightsId];
                     IDictionary<int, List<ILightWithId>> lightsPreGroup = new Dictionary<int, List<ILightWithId>>();
+                    var managers = Object.FindObjectsOfType<TrackLaneRingsManager>();
                     foreach (ILightWithId light in Lights)
                     {
                         if (light is MonoBehaviour monoBehaviour)
                         {
                             int z = Mathf.RoundToInt(monoBehaviour.transform.position.z);
+
+                            var ring = monoBehaviour.GetComponentInParent<TrackLaneRing>();
+                            if (ring != null)
+                            {
+                                var mngr = managers.FirstOrDefault(it => it.Rings.IndexOf(ring) >= 0);
+                                if (mngr != null)
+                                {
+                                    z = 1000 + mngr.Rings.IndexOf(ring);
+                                }
+                            }
+
                             if (lightsPreGroup.TryGetValue(z, out List<ILightWithId> list))
                             {
                                 list.Add(light);


### PR DESCRIPTION
This looks like it could change a lot of things but it actually results in the same functionallity everywhere but in Greenday where the current method has rng that results in the 30 rings being grouped into between 6 and 15 or so prop ids.

+1000 is to stop rings being grouped with other nearby objects and doesn't change the order of the final groupings.