### PR TITLE
Add _rotation to control first ring movement

### DIFF
--- a/Chroma/HarmonyPatches/TrackLaneRingsRotationEffectSpawner.cs
+++ b/Chroma/HarmonyPatches/TrackLaneRingsRotationEffectSpawner.cs
@@ -105,12 +105,14 @@
                     float step = ((float?)Trees.at(dynData, STEP)).GetValueOrDefault(rotationStep);
                     float prop = ((float?)Trees.at(dynData, PROP)).GetValueOrDefault(____rotationPropagationSpeed);
                     float speed = ((float?)Trees.at(dynData, SPEED)).GetValueOrDefault(____rotationFlexySpeed);
+                    float rotation = ((float?)Trees.at(dynData, ROTATION)).GetValueOrDefault(____rotation);
 
                     float stepMult = ((float?)Trees.at(dynData, STEPMULT)).GetValueOrDefault(1f);
                     float propMult = ((float?)Trees.at(dynData, PROPMULT)).GetValueOrDefault(1f);
                     float speedMult = ((float?)Trees.at(dynData, SPEEDMULT)).GetValueOrDefault(1f);
+                    float rotationMult = ((float?)Trees.at(dynData, ROTATIONMULT)).GetValueOrDefault(1f);
 
-                    TriggerRotation(____trackLaneRingsRotationEffect, rotRight, ____rotation, step * stepMult, prop * propMult, speed * speedMult);
+                    TriggerRotation(____trackLaneRingsRotationEffect, rotRight, rotation * rotationMult, step * stepMult, prop * propMult, speed * speedMult);
                     return false;
                 }
             }

--- a/Chroma/HarmonyPatches/TrackLaneRingsRotationEffectSpawner.cs
+++ b/Chroma/HarmonyPatches/TrackLaneRingsRotationEffectSpawner.cs
@@ -110,9 +110,8 @@
                     float stepMult = ((float?)Trees.at(dynData, STEPMULT)).GetValueOrDefault(1f);
                     float propMult = ((float?)Trees.at(dynData, PROPMULT)).GetValueOrDefault(1f);
                     float speedMult = ((float?)Trees.at(dynData, SPEEDMULT)).GetValueOrDefault(1f);
-                    float rotationMult = ((float?)Trees.at(dynData, ROTATIONMULT)).GetValueOrDefault(1f);
 
-                    TriggerRotation(____trackLaneRingsRotationEffect, rotRight, rotation * rotationMult, step * stepMult, prop * propMult, speed * speedMult);
+                    TriggerRotation(____trackLaneRingsRotationEffect, rotRight, rotation, step * stepMult, prop * propMult, speed * speedMult);
                     return false;
                 }
             }

--- a/Chroma/Plugin.cs
+++ b/Chroma/Plugin.cs
@@ -41,6 +41,8 @@
         internal const string STARTCOLOR = "_startColor";
         internal const string STEP = "_step";
         internal const string STEPMULT = "_stepMult";
+        internal const string ROTATION = "_rotation";
+        internal const string ROTATIONMULT = "_rotationMult";
 
         internal static readonly Harmony _harmonyInstanceCore = new Harmony(HARMONYIDCORE);
         internal static readonly Harmony _harmonyInstance = new Harmony(HARMONYID);

--- a/Chroma/Plugin.cs
+++ b/Chroma/Plugin.cs
@@ -42,7 +42,6 @@
         internal const string STEP = "_step";
         internal const string STEPMULT = "_stepMult";
         internal const string ROTATION = "_rotation";
-        internal const string ROTATIONMULT = "_rotationMult";
 
         internal static readonly Harmony _harmonyInstanceCore = new Harmony(HARMONYIDCORE);
         internal static readonly Harmony _harmonyInstance = new Harmony(HARMONYID);

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ Example of _customData:
     * Can only be applied to ring rotation events.
     * `"_nameFilter"`: (string) Causes event to only affect rings with a listed name (e.g. SmallTrackLaneRings, BigTrackLaneRings).
     * `"_reset"`: (bool) Will reset the rings when set to true (Overwrites values below).
-    * `"_step"`: (float) Dictates how far the rings will spin.
+    * `"_rotation"`: (float) Dictates how far the first ring will spin.
+    * `"_step"`: (float) Dictates how much rotation is added between each ring.
     * `"_prop"`: (float) Dictates the rate at which rings behind the first one have physics applied to them.  High value makes all rings move simultaneously, low value gives them [significant delay](https://streamable.com/vsdr9).
     * `"_speed"`: (float) Dictates the [speed multiplier of the rings](https://streamable.com/fxlse).
     * `"_direction"`: (int) Direction to spin the rings (1 spins clockwise, 0 spins counter-clockwise).


### PR DESCRIPTION
Because the first ring always spinning 90 degrees is "limiting"
This allows for more subtle (<90) spin effects that wobble the rings a little AND bigger spins (>90) that would previously have required stacking events

There's some overlap here with the direction field but nothing to be done about that