### PR TITLE
Fixes for technicolor gradient walls

### DIFF
--- a/Chroma/Colorizer/ObstacleColorizer.cs
+++ b/Chroma/Colorizer/ObstacleColorizer.cs
@@ -28,7 +28,7 @@
             OCColorManager.GetOCColorManager(oc)?.SetObstacleColor(color);
         }
 
-        public static void SetAllObstacleColors(Color color)
+        public static void SetAllObstacleColors(Color? color)
         {
             OCColorManager.SetGlobalObstacleColor(color);
         }
@@ -112,7 +112,7 @@
                 return occm;
             }
 
-            internal static void SetGlobalObstacleColor(Color color)
+            internal static void SetGlobalObstacleColor(Color? color)
             {
                 _globalColor = color;
             }
@@ -134,7 +134,7 @@
 
             internal void SetActiveColors()
             {
-                Color finalColor = _color ?? _globalColor ?? _color_Original;
+                Color finalColor = _globalColor ?? _color ?? _color_Original;
                 ParametricBoxFrameController obstacleFrame = _obstacleFrameAccessor(ref _stretchableObstacle);
 
                 if (finalColor == obstacleFrame.color)

--- a/Chroma/HarmonyPatches/ScenesTransition/SceneTransitionHelper.cs
+++ b/Chroma/HarmonyPatches/ScenesTransition/SceneTransitionHelper.cs
@@ -31,7 +31,7 @@
 
             if (!foundReturn)
             {
-                Plugin.Logger.Log("Failed to find ret!", IPA.Logging.Logger.Level.Error);
+                Chroma.Plugin.Logger.Log("Failed to find ret!", IPA.Logging.Logger.Level.Error);
             }
 
             return instructionList.AsEnumerable();
@@ -74,8 +74,8 @@
             bool legacyOverride = customBeatmapData.beatmapEventsData.Any(n => n.value >= LegacyLightHelper.RGB_INT_OFFSET);
             if (legacyOverride)
             {
-                Plugin.Logger.Log("Legacy Chroma Detected...", IPA.Logging.Logger.Level.Warning);
-                Plugin.Logger.Log("Please do not use Legacy Chroma for new maps as it is deprecated and its functionality in future versions of Chroma cannot be guaranteed", IPA.Logging.Logger.Level.Warning);
+                Chroma.Plugin.Logger.Log("Legacy Chroma Detected...", IPA.Logging.Logger.Level.Warning);
+                Chroma.Plugin.Logger.Log("Please do not use Legacy Chroma for new maps as it is deprecated and its functionality in future versions of Chroma cannot be guaranteed", IPA.Logging.Logger.Level.Warning);
             }
 
             ChromaController.ToggleChromaPatches((chromaRequirement || legacyOverride) && ChromaConfig.Instance.CustomColorEventsEnabled);


### PR DESCRIPTION
Fixes:

- Technicolor 1.0.4 was throwing method not found exceptions on SetAllObstacleColors(Color color) because color wasn't nullable
- Gradient walls no longer worked due to a change in priority of the global wall color