### PR TITLE
Add/fog settings

### DIFF
--- a/Chroma/Chroma.csproj
+++ b/Chroma/Chroma.csproj
@@ -43,6 +43,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AnimationHelper.cs" />
+    <Compile Include="HarmonyPatches\BloomFogSO.cs" />
     <Compile Include="HarmonyPatches\GameplayCoreInstaller.cs" />
     <Compile Include="HarmonyPatches\PlayerHeadAndObstacleInteraction.cs" />
     <Compile Include="HarmonyPatches\ScenesTransition\TutorialScenesTransitionSetupDataSO.cs" />
@@ -54,6 +55,7 @@
     <Compile Include="ChromaObjectData.cs" />
     <Compile Include="ChromaPatch.cs" />
     <Compile Include="HarmonyPatches\BeatmapDataZenModeTransform.cs" />
+    <Compile Include="Lighting\ChromaFogManager.cs" />
     <Compile Include="Lighting\ChromaGradientController.cs" />
     <Compile Include="Lighting\ChromaRingsRotationEffect.cs" />
     <Compile Include="HarmonyPatches\BeatmapDataTransformHelper.cs" />

--- a/Chroma/ChromaController.cs
+++ b/Chroma/ChromaController.cs
@@ -8,6 +8,7 @@
     using Chroma.Colorizer;
     using Chroma.HarmonyPatches;
     using Chroma.Settings;
+    using CustomJSONData;
     using CustomJSONData.CustomBeatmap;
     using HarmonyLib;
     using IPA.Utilities;
@@ -125,6 +126,8 @@
                     {
                         EnvironmentEnhancementManager.Init(customBeatmap, beatmapObjectSpawnController.noteLinesDistance);
                     }
+
+                    ChromaFogManager.Initialize(coreSetup.GetComponent<CustomEventCallbackController>(), customBeatmap);
                 }
 
                 // please let me kill legacy

--- a/Chroma/HarmonyPatches/BloomFogSO.cs
+++ b/Chroma/HarmonyPatches/BloomFogSO.cs
@@ -1,0 +1,12 @@
+﻿namespace Chroma.HarmonyPatches
+{
+    [ChromaPatch(typeof(BloomFogSO))]
+    [ChromaPatch("Setup")]
+    internal static class BloomFogSOSetupPatch
+    {
+        private static void Prefix(BloomFogSO __instance)
+        {
+            ChromaFogManager.bloomFogSO = __instance;
+        }
+    }
+}

--- a/Chroma/Lighting/ChromaFogManager.cs
+++ b/Chroma/Lighting/ChromaFogManager.cs
@@ -1,0 +1,88 @@
+﻿namespace Chroma
+{
+    using Chroma.Utils;
+    using CustomJSONData;
+    using CustomJSONData.CustomBeatmap;
+    using System;
+    using System.Collections;
+    using UnityEngine;
+    using static Chroma.Plugin;
+
+    internal static class ChromaFogManager
+    {
+        internal static BloomFogSO bloomFogSO;
+        internal static BloomFogEnvironmentParams originalFogParams;
+
+        internal static void Initialize(CustomEventCallbackController customEventCallback, CustomBeatmapData customBeatmap)
+        {
+            originalFogParams = bloomFogSO.defaultForParams;
+
+            customEventCallback.AddCustomEventCallback(HandleFogCustomEvents);
+
+            object levelFogSettings = Trees.at(customBeatmap.beatmapCustomData, FOGSETTINGS);
+
+            if (levelFogSettings != null)
+            {
+                BloomFogEnvironmentParams fogParams = ParseFogSettingsFromCustomData(levelFogSettings);
+                bloomFogSO.defaultForParams = fogParams;
+                bloomFogSO.transitionFogParams = fogParams;
+            }
+        }
+
+        private static void HandleFogCustomEvents(CustomEventData customEvent)
+        {
+            switch (customEvent.type)
+            {
+                case SETFOGSETTINGS:
+                    BloomFogEnvironmentParams parsedParams = ParseFogSettingsFromCustomData(customEvent.data);
+                    bloomFogSO.defaultForParams = parsedParams;
+                    bloomFogSO.transitionFogParams = parsedParams;
+                    bloomFogSO.transition = 0;
+                    break;
+
+                case ANIMATEFOGSETTINGS:
+                    dynamic newSettings = Trees.at(customEvent.data, NEWFOGSETTINGS);
+                    BloomFogEnvironmentParams newParams = ParseFogSettingsFromCustomData(newSettings);
+                    bloomFogSO.transitionFogParams = newParams;
+                    bloomFogSO.transition = 0;
+
+                    float duration = ((float?)Trees.at(customEvent.data, DURATION)) ?? 1;
+                    string easingString = ((string)Trees.at(customEvent.data, EASING)) ?? "easeLinear";
+                    Functions easing = (Functions)Enum.Parse(typeof(Functions), easingString);
+
+                    SharedCoroutineStarter.instance.StartCoroutine(AnimateFogSettings(duration, easing));
+                    break;
+
+                case RESETFOGSETTINGS:
+                    bloomFogSO.defaultForParams = originalFogParams;
+                    bloomFogSO.transitionFogParams = originalFogParams;
+                    bloomFogSO.transition = 0;
+                    break;
+            }
+        }
+
+        private static IEnumerator AnimateFogSettings(float duration, Functions easing)
+        {
+            float t = 0;
+            while (t < 1)
+            {
+                bloomFogSO.transition = Easings.Interpolate(t / duration, easing);
+                t += Time.deltaTime;
+                yield return new WaitForEndOfFrame();
+            }
+            bloomFogSO.transition = 1;
+        }
+
+        private static BloomFogEnvironmentParams ParseFogSettingsFromCustomData(dynamic data)
+        {
+            BloomFogEnvironmentParams fogParams = ScriptableObject.CreateInstance<BloomFogEnvironmentParams>();
+            
+            fogParams.attenuation = ((float?)Trees.at(data, ATTENUATION)).GetValueOrDefault(0.1f);
+            fogParams.offset = ((float?)Trees.at(data, OFFSET)).GetValueOrDefault(0f);
+            fogParams.heightFogStartY = ((float?)Trees.at(data, FOGFLOOR)).GetValueOrDefault(-300f);
+            fogParams.heightFogHeight = ((float?)Trees.at(data, FOGHEIGHT)).GetValueOrDefault(10f);
+
+            return fogParams;
+        }
+    }
+}

--- a/Chroma/Plugin.cs
+++ b/Chroma/Plugin.cs
@@ -54,6 +54,16 @@
         internal const string OBJECTROTATION = "_rotation";
         internal const string LOCALROTATION = "_localRotation";
 
+        internal const string SETFOGSETTINGS = "SetFogSettings";
+        internal const string ANIMATEFOGSETTINGS = "AnimateFogSettings";
+        internal const string RESETFOGSETTINGS = "ResetFogSettings";
+        internal const string FOGSETTINGS = "_fogSettings";
+        internal const string NEWFOGSETTINGS = "_newFogSettings";
+        internal const string ATTENUATION = "_attenuation";
+        internal const string OFFSET = "_offset";
+        internal const string FOGFLOOR = "_fogFloor";
+        internal const string FOGHEIGHT = "_fogHeight";
+
         internal static readonly Harmony _harmonyInstanceCore = new Harmony(HARMONYIDCORE);
         internal static readonly Harmony _harmonyInstance = new Harmony(HARMONYID);
 

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ Allows you to [control the in-game fog](https://cdn.discordapp.com/attachments/5
 
 * **Fog Settings** object (used throughout)
   * `"_attenuation"`: (float) Controls the strength of the fog. A higher number leads to a darker environment. Values close to 0 are recommended. Default is `0.01`
-  * `"_offset": (float) Controls the fog distance to the player. Default is `0`.
-  * `"_fogFloor": (float) Any solid lasers beneath this Y value will be transparent. Default is `-300`.
-  * `"_fogHeight": (float) Controls the distance from the fog floor where solid lasers will fade into transparency.
+  * `"_offset"`: (float) Controls the fog distance to the player. Default is `0`.
+  * `"_fogFloor"`: (float) Any solid lasers beneath this Y value will be transparent. Default is `-300`.
+  * `"_fogHeight"`: (float) Controls the distance from the fog floor where solid lasers will fade into transparency. Default is `10`.
 
 * Per-level Fog Settings
   * `Info.dat` -> Difficulty -> `"_customData"`

--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ Example of _customData:
 ## Animation
 See [Noodle Extensions documentation](https://github.com/Aeroluna/NoodleExtensions/blob/master/Documentation/AnimationDocs.md#_color)
 
+## Fog
+Allows you to [control the in-game fog](https://cdn.discordapp.com/attachments/587440801546502175/839749737670639626/unknown.png). This does *not* affect particles, or the smoke around the environment.
+
+* **Fog Settings** object (used throughout)
+  * `"_attenuation"`: (float) Controls the strength of the fog. A higher number leads to a darker environment. Values close to 0 are recommended. Default is `0.01`
+  * `"_offset": (float) Controls the fog distance to the player. Default is `0`.
+  * `"_fogFloor": (float) Any solid lasers beneath this Y value will be transparent. Default is `-300`.
+  * `"_fogHeight": (float) Controls the distance from the fog floor where solid lasers will fade into transparency.
+
+* Per-level Fog Settings
+  * `Info.dat` -> Difficulty -> `"_customData"`
+    * `"_fogSettings"`: (Fog Settings) Controls the initial fog settings for the difficulty.
+
+* [Custom Event](https://github.com/Aeroluna/NoodleExtensions/blob/master/Documentation/AnimationDocs.md#custom-events) Types
+  * `"_events"` -> `"_customData"` -> `"_customEvents"`
+    * `"SetFogSettings"` - Instantly sets fog settings. `"_data"` is a Fog Settings object.
+    * `"ResetFogSettings"` - Resets fog to the settings used by the environment. Data is not required.
+    * `"AnimateFogSettings"` - Animates between the currently active settings, and the provided settings
+      * `"_newFogSettings"`: (Fog Settings) The new settings.
+      * `"_duration"`: (float) The duration of the transition period. Default is `1`.
+      * `"_easing"`: (Function) An additional function that controls transition easing. See [easings.net](https://easings.net/) for a list of all available easings. Default is `easeLinear`.
+
 ## Info.dat Data
 * Environment Removal
   * DEPRECATED use _environment.


### PR DESCRIPTION
This PR adds a method of manipulating the fog in environments.

![example](https://cdn.discordapp.com/attachments/587440801546502175/839749737670639626/unknown.png)

You can manipulate fog per-difficulty in the `Info.dat` `_customData` objects, or take advantage of some custom events to manipulate them in the Difficulty.dat files. All of this has been documented in README.