### PR TITLE
Fix plugin logger references

### DIFF
--- a/Chroma/HarmonyPatches/ScenesTransition/SceneTransitionHelper.cs
+++ b/Chroma/HarmonyPatches/ScenesTransition/SceneTransitionHelper.cs
@@ -31,7 +31,7 @@
 
             if (!foundReturn)
             {
-                Plugin.Logger.Log("Failed to find ret!", IPA.Logging.Logger.Level.Error);
+                Chroma.Plugin.Logger.Log("Failed to find ret!", IPA.Logging.Logger.Level.Error);
             }
 
             return instructionList.AsEnumerable();
@@ -74,8 +74,8 @@
             bool legacyOverride = customBeatmapData.beatmapEventsData.Any(n => n.value >= LegacyLightHelper.RGB_INT_OFFSET);
             if (legacyOverride)
             {
-                Plugin.Logger.Log("Legacy Chroma Detected...", IPA.Logging.Logger.Level.Warning);
-                Plugin.Logger.Log("Please do not use Legacy Chroma for new maps as it is deprecated and its functionality in future versions of Chroma cannot be guaranteed", IPA.Logging.Logger.Level.Warning);
+                Chroma.Plugin.Logger.Log("Legacy Chroma Detected...", IPA.Logging.Logger.Level.Warning);
+                Chroma.Plugin.Logger.Log("Please do not use Legacy Chroma for new maps as it is deprecated and its functionality in future versions of Chroma cannot be guaranteed", IPA.Logging.Logger.Level.Warning);
             }
 
             ChromaController.ToggleChromaPatches((chromaRequirement || legacyOverride) && ChromaConfig.Instance.CustomColorEventsEnabled);


### PR DESCRIPTION
Currently there are conflicts when using Plugin.Logger.  This PR explicitly states to use the Chroma logger.